### PR TITLE
fix: throw err if buf is large

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ js: webassembly/crc64_ecma_182.cc webassembly/crc64_ecma_182.h
 			'writeArrayToMemory',\
 			'UTF8ToString'\
 		]" \
+		-s ALLOW_MEMORY_GROWTH=1 \
 		-s WASM=0 \
 		-s NODEJS_CATCH_EXIT=0 \
 		-s NODEJS_CATCH_REJECTION=0 \


### PR DESCRIPTION
fix https://github.com/XadillaX/crc64-ecma182.js/issues/3